### PR TITLE
Use a list-group (Bootstrap)

### DIFF
--- a/content/membership/members/_index.adoc
+++ b/content/membership/members/_index.adoc
@@ -1,6 +1,7 @@
 ---
 title: "Explore Our Members"
 seo_title: "Explore our members - Eclipse AsciiDoc"
+headline: "Our Members"
 description: "Discover our Eclipse AsciiDoc members."
 keywords: ["Eclipse AsciiDoc members", "AsciiDoc open source members", "open source AsciiDoc"]
 aliases:

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -1,4 +1,4 @@
-<!-- 
+<!--
   Copyright (c) 2021 Eclipse Foundation, Inc.
 
   This program and the accompanying materials are made available under the
@@ -22,27 +22,15 @@
     {{$parentItem := . }}
       {{ if and (.HasChildren) (eq $currentSection $parentItem.Identifier) }}
         <aside id="main-sidebar">
-        {{ range .Children }}
-          {{ if .HasChildren }}
-            <div class="row sidebar-sub-items">
-              {{ range .Children }}
-                <div class="row sidebar-sub-item{{ if eq $currentPage.Title .Name }} active{{ end }}">
-                  <a href="{{ .URL }}" {{ if eq $currentPage.Title .Name }}class="active"{{ end }}>
-                    <div class="col-xs-6"></div>
-                    <div class="col-xs-18 sidebar-text">{{ .Name }}</div>
-                  </a>
-                </div>
-              {{ end }}
-            </div>
-          {{ else if or (eq $parentItem.Identifier $currentSection) (eq .Parent $currentSection) }}
-            <div class="row sidebar-item{{ if eq $currentPage.Title .Name }} active{{ end }}">
-              <a href="{{ .URL }}" {{ if eq $currentPage.Title .Name }}class="active"{{ end }}>
-                <div class="col-xs-6">{{ .Pre }}</div>
-                <div class="col-xs-18 sidebar-text">{{ .Name }}</div>
-              </a>
-            </div>
+          <div class="list-group">
+          {{ range .Children }}
+            {{ if or (eq $parentItem.Identifier $currentSection) (eq .Parent $currentSection) }}
+            <a href="{{ .URL }}" class="list-group-item list-group-item-action{{ if eq $currentPage.Title .Name }} active{{ end }}"{{ if eq $currentPage.Title .Name }} aria-current="true"{{ end }}>
+              {{ .Pre}} {{ .Name }}
+            </a>
+            {{ end }}
           {{ end }}
-        {{ end }}
+          </div>
         </aside>
       {{ end }}
   {{ end }}

--- a/less/_components/sidebar.less
+++ b/less/_components/sidebar.less
@@ -1,76 +1,40 @@
 /*!
  * Copyright (c) 2021 Eclipse Foundation, Inc.
- * 
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0.
- * 
+ *
  * Contributors:
  *   Eric Poirier <eric.poirier@eclipse-foundation.org>
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
 */
 
 
 #main-sidebar {
-	&:after{
-	  display:none;
-	}
-  margin-top:50px;
-  .sidebar-item {
-    margin-bottom:20px;
-    background-color: @brand-primary;
-    padding:17px 0 10px;
-    &.active {
-      background-color: @brand-secondary;
-      a {
-        color:#fff;
-      }
-      &:hover {
-        background-color: darken(@brand-secondary, 15%);
-      }
-    }
-    &:hover:not(.active) {
-      background-color: darken(@brand-primary, 15%);
-      a {
-        color:darken(@main-sidebar-color, 20%);
-      }
-    }
-  }
-  .sidebar-sub-items {
-    background-color:#fff;
-    margin-top:-20px;
+  .list-group {
+    margin-top: 40px;
+
     a {
-      &:hover {
-        font-weight:bold;
+      display: flex;
+      align-items: center;
+      color: #3d3d3d;
+
+      &.active {
+        color: #fff;
+      }
+
+      > svg {
+        width: 40px;
+        height: 40px;
+        stroke-width: 1;
+        margin: 0 10px 0 0;
       }
     }
   }
-  .sidebar-sub-item {
-    padding:0 0 8px 15px;
-    margin-bottom:0;
-    a.active {
-      .sidebar-text {
-        font-weight:bold;
-      }
-    }
-    &:first-child {
-      margin-top:15px;
-    }
-    &:last-child {
-      margin-bottom:15px;
-    }
-  }
-  a {
-    display: block;
-    .feather {
-      width:40px;
-      height:40px;
-      stroke-width: 1;
-      margin: 0 20px 0 0px;
-    }
-    .sidebar-text {
-      padding:8px 0 0;
-    }
+
+  &:after {
+    display: none;
   }
 }


### PR DESCRIPTION
I had trouble figuring out that the sidebar was a list of buttons with an active item.
This new design requires less HTML elements and hopefully easier to understand.

Since Solstice theme relies on Bootstrap, I decided to use: https://getbootstrap.com/docs/5.0/components/list-group/#active-items


![button-list](https://user-images.githubusercontent.com/333276/113611197-7afdc900-964e-11eb-9c5c-608e7318a35b.gif)
