### PR TITLE
Migrate Repo to Eclipse Gitlab

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,5 +1,12 @@
 = asciidoc-wg.eclipse.org
 
+---
+**NOTE**
+
+This project was migrated to [Eclipse Gitlab](https://gitlab.eclipse.org/eclipse-wg/asciidoc-wg/asciidoc-wg.eclipse.org/) on September 21, 2021.
+
+---
+
 The https://asciidoc-wg.eclipse.org website is generated with https://gohugo.io/documentation/[Hugo].
 
 The AsciiDoc Working Group drives the standardization, adoption, and evolution of AsciiDoc. This group encourages and shapes the open, collaborative development of the AsciiDoc language and its processors.


### PR DESCRIPTION
Our Netlify account is now configured to build previews and production builds using this new Gitlab repository https://gitlab.eclipse.org/eclipse-wg/asciidoc-wg/asciidoc-wg.eclipse.org/.  I will make this repository read-only once this PR is merged in.

//cc @mojavelinux  @ahus1 @Mogztter 

I will grant write access today. Please let me know if you have any questions/concerns.